### PR TITLE
Add `isOverflow` to maxsize modifier's result

### DIFF
--- a/src/modifiers/maxSize.js
+++ b/src/modifiers/maxSize.js
@@ -19,6 +19,14 @@ export default {
     state.modifiersData[name] = {
       width: width - overflow[widthProp] - x,
       height: height - overflow[heightProp] - y,
+      isOverflow:
+        overflow[widthProp] > 0
+          ? overflow[heightProp] > 0
+            ? true
+            : 'width'
+          : overflow[heightProp] > 0
+          ? 'height'
+          : false,
     };
   },
 };


### PR DESCRIPTION
Hi @atomiks 

We're using popper in our component library, and recently we tried to apply `popper-maxsize-modifier`.
When I'm trying it out, I discovered a problem:
1. Initially we have a popper with a small size that doesn't cause overflow
2. All modifiers run, including maxsize modifier, and then the generated height/width is applied as max-height/max-width to popper. Note that the max-height/max-width is smaller than the available space because there's no overflow. 
3. The popper increase its size.
4. All modifiers run again. But because popper has max-height/max-width applied already, it does not grow bigger, even though there's more space available.

Here's a [codesandbox](https://codesandbox.io/s/funny-neumann-gxncp?file=/src/index.js) for this.

I would like for the maxsize modifier to tell me if overflow happens or not, so I don't need to apply max-height/max-width if there's no overflow. It is possible to achieve the same by running another `detectOverflow` after maxsize modifier. But that would cause overhead. 
Let me know wdyt :)